### PR TITLE
[Cycode] Fix for IaC misconfiguration - Ensure that Service Account Tokens are only mounted where necessary

### DIFF
--- a/deploy/kubernetes/manifests/extras/46-mizutest-outbound-tls-dep.yaml
+++ b/deploy/kubernetes/manifests/extras/46-mizutest-outbound-tls-dep.yaml
@@ -46,3 +46,4 @@ spec:
         #   readOnlyRootFilesystem: true
       nodeSelector:
         beta.kubernetes.io/os: linux
+      automountServiceAccountToken: false


### PR DESCRIPTION
[Cycode] Fix for IaC misconfiguration - Ensure that Service Account Tokens are only mounted where necessary